### PR TITLE
Update instruction for including the library using npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can also pull Iodine into your project via NPM:
 ```js
 npm i @kingshott/iodine
 
-import Iodine from '@kingshott/iodine';
+import '@kingshott/iodine';
 ```
 
 ## Usage


### PR DESCRIPTION
Thanks for this amazing library. I noticed a minor thing when I was using it in my project.
Iodine doesn't export a module so this instruction `import Iodine from '@kingshott/iodine';` generates a warning when compiling the bundle (I use rollup but I assume it would be the same with webpack or microbundle).