### PR TITLE
fix/capital Letter in iodine-Rule

### DIFF
--- a/src/iodine.js
+++ b/src/iodine.js
@@ -59,8 +59,8 @@ export class Iodine {
       minimum: `[FIELD] must not be less than '[PARAM]' in size or character length`,
       max: `[FIELD] must be less than or equal to [PARAM]`,
       min: `[FIELD] must be greater than or equal to [PARAM]`,
-      maxlength: `[FIELD] must not be greater than '[PARAM]' in character length`,
-      minlength: `[FIELD] must not be less than '[PARAM]' character length`,
+      maxLength: `[FIELD] must not be greater than '[PARAM]' in character length`,
+      minLength: `[FIELD] must not be less than '[PARAM]' character length`,
       notIn: `[FIELD] must not be one of the following options: [PARAM]`,
       numeric: `[FIELD] must be numeric`,
       optional: `[FIELD] is optional`,
@@ -247,7 +247,7 @@ export class Iodine {
    **/
   isMaximum(value, limit) {
     console.warn(
-      "isMaximum (maximum) is deprecated. Use isMax (max) for validating the maximum value of a number or isMaxLength (maxlength) for validating the length of a string"
+      "isMaximum (maximum) is deprecated. Use isMax (max) for validating the maximum value of a number or isMaxLength (maxLength) for validating the length of a string"
     );
     value = typeof value === "string" ? value.length : value;
 
@@ -260,7 +260,7 @@ export class Iodine {
    **/
   isMinimum(value, limit) {
     console.warn(
-      "isMinimum (minimum) is deprecated. Use isMin (min) for validating the minimum value of a number or isMinLength (minlength) for validating the length of a string"
+      "isMinimum (minimum) is deprecated. Use isMin (min) for validating the minimum value of a number or isMinLength (minLength) for validating the length of a string"
     );
     value = typeof value === "string" ? value.length : value;
 


### PR DESCRIPTION
Hi Matt,

just a quick fix for the new rules `isMinLength` and `isMaxLength`.

When I used the rules in the way, they were written in the deprecation-hint or error-message object (**minlength**/ **maxlength**), the validation fails, because the generated rule is `isMinlength()` or `isMaxlength()`. 
If I use the `minLength` or `maxLength` rule, it gets validated but no errormessage is shown.


Changes
---
- fixes the missing capital Letter `L` in the rule `minLength` and `maxLength`
- adds the snakecase spelling to the hint at the deprecated rules aswell

I hope this PR fulfilles the contribution rules.

Cheers and thanks for this great library (and Tut: https://itnext.io/iodinejs-a-micro-validation-library-705ba388586f)!
 🙌🏼