### PR TITLE
Allow async by using separate asysnc functions

### DIFF
--- a/src/iodine.js
+++ b/src/iodine.js
@@ -421,10 +421,42 @@ export class Iodine {
 
   /**
    * Determine whether the given value meets the given rules.
+   *
+   **/
+  async asyncIs(value, rules = []) {
+    if (!rules.length) return true;
+
+    if (rules[0] === "optional" && this.isOptional(value)) return true;
+
+    for (let index in rules) {
+      if (rules[index] === "optional") continue;
+
+      const chunks = rules[index].split(":");
+      const ruleName = chunks.shift();
+      let rule = ruleName[0].toUpperCase() + ruleName.slice(1);
+
+      let result = await this[`is${rule}`].apply(this, [value, chunks.join(":")]);
+
+      if (!result) return await rules[index];
+    }
+
+    return true;
+  }
+
+  /**
+   * Determine whether the given value meets the given rules.
    * @returns true if the item passes every rule, otherwise returns false
    **/
   isValid(value, rules = []) {
     return this.is(value, rules) === true;
+  }
+
+  /**
+   * Determine whether the given value meets the given rules.
+   * @returns true if the item passes every rule, otherwise returns false
+   **/
+  async asyncIsValid(value, rules = []) {
+    return await this.asyncIs(value, rules) === true;
   }
 
   /**

--- a/tests/test.js
+++ b/tests/test.js
@@ -679,4 +679,23 @@ describe("custom rules", () => {
       `Value must be equal to '2'`
     );
   });
+  
+  /**
+   * Confirm that the 'addRule' method works correctly for async rules.
+   *
+   **/
+  test("it can add async custom rules", async () => {
+	Iodine.addRule("timeoutEquals", (value, param) => { return new Promise(resolve => setTimeout(resolve(value == param), 10));});
+    Iodine.setErrorMessages({ timeoutEquals: `Value must be equal to '[PARAM]' after 10ms` });
+	expect(await Iodine.isTimeoutEquals(1, 1)).toBe(true);
+	expect(await Iodine.isTimeoutEquals(1, 2)).toBe(false);
+	expect(await Iodine.asyncIs(1, ["required", "timeoutEquals:1"])).toBe(true);
+	expect(await Iodine.asyncIs(1, ["required", "timeoutEquals:2"])).toBe("timeoutEquals:2");
+	expect(
+      await Iodine.asyncIsValid(1, ["required", "integer", "timeoutEquals:1"])
+    ).toBe(true);
+    expect(
+      await Iodine.asyncIsValid(1, ["required", "integer", "timeoutEquals:2"])
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
Resolves #27 
This pull requests allows us to use Iodine with async validation rules.
To make this a non-breaking change, we can use it like below:

## Create Asynchronous Custom Rules:
```
//for example a servercall with Fetch or another Promise
Iodine.setErrorMessages({ timeoutEquals: `Value must be equal to '[PARAM]' after 10ms` });

Iodine.addRule("timeoutEquals", (value, param) => {
	return new Promise(resolve => setTimeout(resolve(value == param), 10));
});
```
## Use it like so:
```
//single rule check
let value = 1;
let asyncEqualsIsValid = await Iodine.isTimeoutEquals(value, 1);

//multiple rules
let asyncIsValid = await Iodine.asyncIsValid(1, ["required", "integer", "timeoutEquals:1"]);
```

