### PR TITLE
Add support for schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- Screenshot -->
 <p align="center">
     <img src="resources/example.png" alt="Code example">
@@ -83,6 +84,21 @@ let item_2 = 'string';
 
 Iodine.isValid(item_1, ['required', 'integer']); // true
 Iodine.isValid(item_2, ['required', 'integer']); // false
+```
+
+### Schema validation
+
+If you want to compare an object against a schema. In other words, you want to run a list of checks against a list of values, then you can use the `isValidSchema` helper method. **Note** : This method uses `isValid`under the hood, hence it returns a `boolean`.
+
+```js
+Iodine.isValidSchema(
+	{ email: 'welcome@to.iodine', password: 'abcdefgh', fullname: 'John Doe' },
+	{
+	  email: [ 'required' , 'email' ],
+	  password: [ 'required' , 'minLength:6' ],
+	  fullname: [ 'required' , 'minLength:3' ]
+	}
+); // true
 ```
 
 ## Additional parameters

--- a/src/iodine.js
+++ b/src/iodine.js
@@ -422,6 +422,29 @@ export class Iodine {
   }
 
   /**
+   * Determine whether the given dictionary of values meets the given schema.
+   *
+   */
+  isValidSchema(values = {}, schema = {}) {
+    const keys = Object.keys(schema);
+
+    if(keys.length === 0) return true;
+
+    for(let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+
+        if(!values.hasOwnProperty(key)) return false;
+
+        const value = values[key];
+        const rules = schema[key];
+
+        if (!this.isValid(value, rules)) return false;
+    }
+
+    return true;
+  }
+
+  /**
    * Replace the default error messages with a new set.
    *
    */

--- a/tests/test.js
+++ b/tests/test.js
@@ -398,6 +398,53 @@ test('return true/false', () => {
 });
 
 /**
+ * Confirm that the 'isValidSchema' method returns the right value against multiple schemas.
+ *
+ */
+test('schema validation', () => {
+
+  expect(
+    Iodine.isValidSchema(
+        { },
+        {
+            website: [ 'required' , 'url' ],
+            ping: [ 'required' , 'integer' ],
+        }
+    )
+  ).toBe(false);
+
+  expect(
+    Iodine.isValidSchema(
+        { email: 'welcome@to.iodine', password: 'abcdefgh', fullname: 'John Doe' },
+        {
+            email: [ 'required' , 'email' ],
+            password: [ 'required' , 'minLength:6' ],
+            fullname: [ 'required' , 'minLength:3' ]
+        }
+    )
+  ).toBe(true);
+
+  expect(
+    Iodine.isValidSchema(
+        { website: 'https://iodine.is', ping: 'ninety' },
+        {
+            website: [ 'required' , 'url' ],
+        }
+    )
+  ).toBe(true);
+
+  expect(
+    Iodine.isValidSchema(
+        { website: 'https://iodine.io', ping: 'ninety' },
+        {
+            website: [ 'required' , 'url' ],
+            ping: [ 'required' , 'integer' ],
+        }
+    )
+  ).toBe(false);
+});
+
+/**
  * Confirm that the 'is' method can handle rules that contain semicolons.
  *
  */


### PR DESCRIPTION
Hello,

To begin with, thank you so much for making this library. It is lightweight, extremely easy to setup, and to use. It's very convenient, and we're using it extensively at my company, so thank you very much.

In most of our projects, we need form validation, and so, each of our forms has its own set of validation rules. But calling the proper Iodine.isXXX method every time became tedious and hard to maintain, and the same code was repeated a lot.

So what we did is simply add "schema validation" to all our forms. Each form has its own schema, but has the exact same validation method. It makes it much easier to do form validation without repeating code, just by describing the field <-> rules associations in each form.

We achieved this result by editing Iodine's code, and adding the method **isValidSchema**.

Hence I thought this could be beneficial to the community using it, and this would be useful.

This pull request contains :
- The edited source code with **isValidSchema** added.
- The test suite associated with it.
- An example associated with it in the README.

Hope it helps and fits the project's philosophy.