### PR TITLE
assert now can accept a rule object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 node_modules
 package-lock.json
 yarn.lock
+*.swp

--- a/src/iodine.js
+++ b/src/iodine.js
@@ -125,8 +125,17 @@ export default class Iodine
 
         if (rules[0] === 'optional' && this.assertOptional(value)) return [];
 
-        return rules.filter(rule => rule !== 'optional')
-                    .map(rule => [rule, this._title(rule.split(':').shift()), rule.split(':').slice(1)]);
+        return rules.filter(rule => rule !== 'optional').map(rule => {
+            if(typeof(rule) === 'string') {
+              return [rule, this._title(rule.split(':').shift()), rule.split(':').slice(1).join(':')]
+            }
+
+           return [
+             `${ rule.rule }:${ rule.param }`,
+             this._title(rule.rule),
+             rule.param
+           ]
+        });
     }
 
     /**
@@ -145,7 +154,7 @@ export default class Iodine
     _validate(value, rules)
     {
         for (let index in rules = this._prepare(value, rules)) {
-            if (! this[`assert${rules[index][1]}`].apply(this, [value, rules[index][2].join(':')])) {
+            if (! this[`assert${rules[index][1]}`].apply(this, [value, rules[index][2]])) {
                 return {
                     valid : false,
                     rule  : rules[index][0],

--- a/tests/test.js
+++ b/tests/test.js
@@ -516,6 +516,74 @@ test('it can validate a single item against multiple rules', () =>
 });
 
 /**
+ * Confirm that the 'assert' method accepts rules as object
+ *
+ */
+test('it can accept rule objects', () => 
+{
+    let pass = {
+        valid : true,
+        rule  : '',
+        error : '',
+    };
+
+    expect(window.Iodine.assert(8, ['required', {
+      rule: 'min',
+      param: 7
+    }, 'max:10'])).toStrictEqual(pass);
+
+    expect(window.Iodine.assert(2, ['required', {
+      rule: 'min',
+      param: 7
+    }, 'max:10'])).toStrictEqual({
+        valid : false,
+        rule  : 'min:7',
+        error : 'Value must be greater than or equal to 7'
+    });
+
+    expect(window.Iodine.assert(5, ['required', {
+      rule: 'in',
+      param: [ 7, 8, 9 ]
+    }, 'max:10'])).toStrictEqual({
+        valid : false,
+        rule  : 'in:7,8,9',
+        error : 'Value must be one of the following options: 7,8,9'
+    });
+
+    expect(window.Iodine.assert(8, ['required', {
+      rule: 'in',
+      param: [ 7, 8, 9 ]
+    }, 'max:10'])).toStrictEqual(pass);
+
+    expect(window.Iodine.assert({
+      hello: 'string',
+      notvalid: 10
+    }, {
+      hello: ['required', {
+          rule: 'string'
+      }],
+      notvalid: ['required', {
+          rule: 'min',
+          param: 12
+      }]
+    })).toStrictEqual({
+        fields: {
+            hello: {
+                error: '',
+                rule: '',
+                valid: true,
+            },
+            notvalid: {
+                error: 'Value must be greater than or equal to 12',
+                rule: 'min:12',
+                valid: false
+            }
+        },
+        valid: false
+    });
+});
+
+/**
  * Confirm that the 'assert' method works correctly.
  *
  */


### PR DESCRIPTION
Hello all,
this pull request allows an user with the ability to pass a rule to assert method using an object.
The rule object is shaped as
```json
{
  "rule": "the rule",
  "param": "the param"
}
```

I think this can be useful when you have to check rules like 'in' where passing the array argument as string can be unhandy