### PR TITLE
Added strict mode flag

### DIFF
--- a/src/iodine.js
+++ b/src/iodine.js
@@ -168,7 +168,7 @@ export default class Iodine
      * Determine if the given content matches the given schema.
      *
      */
-    assert(values, schema)
+    assert(values, schema, strictMode = true)
     {
         if (Array.isArray(schema)) {
             return this._validate(values, schema);
@@ -179,7 +179,7 @@ export default class Iodine
         let result = { valid : true, fields : { } };
 
         for (let i = 0; i < keys.length; i++) {
-            result.fields[keys[i]] = values.hasOwnProperty(keys[i])
+            result.fields[keys[i]] = values.hasOwnProperty(keys[i]) || strictMode === false
                 ? this._validate(values[keys[i]], schema[keys[i]])
                 : this._missing();
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -727,3 +727,41 @@ test('it can add advanced custom rules', () =>
     expect(window.Iodine._error('equals:2')).toBe("Value must be equal to '2'");
     expect(window.Iodine._error('equals', 2)).toBe("Value must be equal to '2'");
 });
+
+/**
+ * 
+ *
+ */
+test('it can switch on/off the strict mode', () =>
+{
+    expect(window.Iodine.assert({}, { test: ['required' ] })).toStrictEqual({
+      valid: false,
+      fields: {
+        test: {
+          error: 'Rules exist, but no value was provided to check',
+          rule: 'None',
+          valid: false
+        }
+      }
+    });
+    expect(window.Iodine.assert({}, { test: ['required' ] }, true)).toStrictEqual({
+      valid: false,
+      fields: {
+        test: {
+          error: 'Rules exist, but no value was provided to check',
+          rule: 'None',
+          valid: false
+        }
+      }
+    });
+    expect(window.Iodine.assert({}, { test: ['required' ] }, false)).toStrictEqual({
+      valid: false,
+      fields: {
+        test: {
+          error: 'Value must be present',
+          rule: 'required',
+          valid: false
+        }
+      }
+    });
+});


### PR DESCRIPTION
Hello all,
in this pr I added a flag to `assert` function enabling rule verification for `undefined` properties.

If no flag is provided or `strictMode = true`, then `assert` behave as always
If `strictMode = false`, then `assert` validate `undefined` values using the required/optional rule

Bye